### PR TITLE
Make runtime skip py37 due to stdlib-list incompat. Add maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
     - python
     - setuptools
   run:
-    - python
+    # stdlib-list is not yet py37 compatible https://github.com/ericdill/depfinder/issues/20
+    - python <=3.7
     - stdlib-list
     - pyyaml
 
@@ -44,3 +45,5 @@ extra:
   recipe-maintainers:
     - ericdill
     - mariusvniekerk
+    - tonyfast
+    - ocefpaf


### PR DESCRIPTION
attn @tonyfast @ocefpaf I've added you as maintainers since you have commit rights on the source project. Also I'm pinning the runtime to less than py37 due to the stdlib-list incompatibility right now.